### PR TITLE
Add detailed module documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,126 @@
+# Physics Engine
+
+A modular 2D physics sandbox written in modern C++ and rendered with SDL3. The
+engine bundles rigid body dynamics, collision detection, and a lightweight UI
+layer into a single component-based architecture that is easy to extend for
+experiments or teaching demos.
+
+## Features
+
+- **Entity-component design** – Every `Entity` owns a renderable `Shape` and a
+  `Physics_Component`, letting you mix rigid bodies, particles, or kinematic
+  actors in the same world. 【F:src/core/entity.h†L16-L54】
+- **Deterministic physics integration** – `Rigid_Body`, `Particle`, and
+  `Kinematic` components expose friction, restitution, and gravity controls so
+  that simulations remain stable across frame rates. 【F:src/physics/rigid_body.h†L11-L47】【F:src/physics/particle.h†L10-L58】
+- **Collision system with resolution** – Circle and rectangle shapes can be
+  checked with broad-phase AABB tests before dispatching to collision
+  resolution routines. 【F:src/collision/collision.h†L6-L29】【F:src/shapes/circle.h†L8-L34】【F:src/shapes/rectangle.h†L8-L36】
+- **SDL3 rendering pipeline** – `Renderer::render_entity` draws world entities
+  and UI overlays using SDL textures and primitive drawing. 【F:src/rendering/renderer.h†L7-L36】
+- **UI actions and overlays** – The `UiManager` manages popup components and
+  queues UI actions triggered during the simulation loop. 【F:src/ui/ui_manager.h†L19-L44】【F:src/ui/components/ui_popup.h†L9-L51】
+- **Extensive automated tests** – Component and UI integration tests cover
+  vector math, physics updates, collision handling, and world orchestration via
+  GoogleTest. 【F:test/components/vector2d_test.cpp†L1-L49】【F:test/components/collision_test.cpp†L1-L83】【F:test/ui/world_test.cpp†L1-L98】
+
+## Repository Layout
+
+| Path | Description |
+| --- | --- |
+| `src/core/` | World orchestration, entity management, and math primitives. |
+| `src/physics/` | Physics component hierarchy and integrators. |
+| `src/collision/` | Collision detection and response helpers. |
+| `src/shapes/` | Renderable geometry primitives shared by physics and rendering. |
+| `src/rendering/` | SDL-backed renderer that draws entities and UI widgets. |
+| `src/ui/` | Immediate-mode style UI components, actions, and manager logic. |
+| `test/components/` | Pure unit tests for math, physics, and collision code. |
+| `test/ui/` | SDL-backed integration tests that exercise the world loop. |
+
+## Build Requirements
+
+- A compiler with **C++20** support.
+- **CMake 3.28** or newer. 【F:CMakeLists.txt†L1-L6】
+- **SDL3 development libraries** discoverable via `find_package(SDL3 REQUIRED)`. 【F:CMakeLists.txt†L18-L19】
+- (Optional) `SDL3_image` if you enable the commented texture loading hooks.
+
+GoogleTest is fetched automatically through `FetchContent`, so no system-wide
+installation is required. 【F:CMakeLists.txt†L8-L17】
+
+## Building the Project
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+The default target compiles the `Physics_Engine` executable along with two test
+runners:
+
+- `Physics_Engine_Component_Tests` for headless unit tests.
+- `Physics_Engine_UI_Tests` for SDL-driven integration checks.
+
+All targets link against SDL3 and are generated in the chosen build directory. 【F:CMakeLists.txt†L21-L114】
+
+## Running the Simulation
+
+1. Build the project.
+2. Ensure SDL3 can create a window on your platform (e.g., X11, Wayland,
+   or Windows/macOS desktop session).
+3. Launch the executable:
+
+   ```bash
+   ./build/Physics_Engine
+   ```
+
+The main loop (`World::update`) handles SDL events, processes UI actions, runs
+physics, and renders entities each frame. 【F:src/core/world.h†L24-L59】 Use the
+arrow keys to nudge the selected entity around (`handle_input` in `main.cpp`). 【F:src/main.cpp†L41-L55】
+
+## Running Tests
+
+After building, execute the GoogleTest suites from the build directory:
+
+```bash
+cd build
+ctest --output-on-failure
+```
+
+Individual binaries can be run directly if you want to focus on a single suite:
+
+```bash
+./Physics_Engine_Component_Tests
+./Physics_Engine_UI_Tests
+```
+
+Both test executables are registered with `gtest_discover_tests`, so `ctest`
+will automatically enumerate the GoogleTest cases. 【F:CMakeLists.txt†L116-L120】
+
+## Extending the Engine
+
+- **Add a new shape** by subclassing `Shape`, implementing `get_type`,
+  `get_bounds`, and `render`, then composing it into an `Entity`. 【F:src/shapes/shape.h†L8-L44】
+- **Create a custom physics component** by deriving from
+  `Physics_Component`, overriding `update`, and exposing configuration knobs
+  similar to `Rigid_Body`. 【F:src/physics/physics_component.h†L9-L59】【F:src/physics/rigid_body.h†L26-L47】
+- **Hook UI controls** by creating a `UiComponent` and pushing `UIAction`
+  instances onto the manager queue. 【F:src/ui/components/ui_component.h†L8-L43】【F:src/ui/ui_action.h†L8-L55】
+
+Because the world stores entities as `std::unique_ptr`, ownership stays clear
+and components can share data through simple pointers or events.
+
+## Detailed Documentation
+
+Additional module-by-module guides live in [`docs/`](docs/README.md), covering
+architecture, core systems, physics, collision detection, shapes, rendering,
+UI, and the automated test suites.
+
+## Troubleshooting
+
+- If SDL3 fails to initialize, verify that your system meets the runtime
+  requirements and that `SDL_GetError()` logs the failure cause inside
+  `World::initializeSdl`. 【F:src/core/world.cpp†L19-L94】
+- Missing UI overlays usually indicate the `UiManager::init` routine was not
+  called; the world constructor handles this once SDL surfaces are ready. 【F:src/core/world.cpp†L96-L177】
+- Physics behaving unexpectedly? Double-check mass, restitution, and gravity
+  flags on each `Physics_Component` before stepping the simulation. 【F:src/physics/physics_component.h†L23-L59】

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation Index
+
+This directory contains deep-dive documentation for each major system in the physics engine. Start with the architectural overview, then explore the module-specific guides as needed:
+
+- [Architecture](architecture.md) – High-level view of the engine flow and major responsibilities.
+- [Core Systems](core.md) – Entities, world orchestration, and math utilities.
+- [Physics Components](physics.md) – Rigid bodies, particles, and other update strategies.
+- [Collision Detection](collision.md) – Dispatch pipeline and collision handling helpers.
+- [Shapes](shapes.md) – Renderable geometry primitives and their traits.
+- [Rendering](rendering.md) – SDL renderer integration and drawing pipeline.
+- [User Interface](ui.md) – UI components, actions, and manager lifecycle.
+- [Testing](testing.md) – Automated coverage and how to extend the suites.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,19 @@
+# Architecture
+
+## Engine Lifecycle
+
+`World` is the top-level coordinator. Initialization wires up the renderer, collision dispatcher, SDL subsystems, the main window, and UI management before simulation begins.【F:src/core/world.h†L29-L60】【F:src/core/world.cpp†L22-L83】 The world keeps track of all entities, maintains collision state across frames, and exposes helpers to add single or batched entities.【F:src/core/world.h†L27-L56】【F:src/core/world.cpp†L42-L51】
+
+Once running, each frame collects elapsed time, clears stale collision pairs, performs collision detection, advances physics, and finally renders both the scene and UI overlays.【F:src/core/world.cpp†L54-L206】 The renderer module draws each entity, while UI components render through the `UiManager` so overlays remain synchronized with the simulation.【F:src/core/world.cpp†L70-L206】
+
+## Data Ownership
+
+Entities own both their visual `Shape` and `Physics_Component` instances via `std::unique_ptr`, so the world can transfer ownership safely when spawning or batching entities.【F:src/core/entity.h†L22-L58】【F:src/core/world.cpp†L42-L51】 World-wide registries of currently and previously colliding entity IDs enable the engine to detect collision exits without storing transient per-entity flags.【F:src/core/world.h†L41-L58】【F:src/core/world.cpp†L148-L178】
+
+## Module Boundaries
+
+- **Core systems** define the world loop, entity model, and math utilities powering every module.【F:src/core/world.h†L24-L60】【F:src/core/vector.h†L8-L27】
+- **Physics components** encapsulate motion logic and expose a uniform update signature consumed by the world.【F:src/physics/physics_component.h†L22-L63】【F:src/core/world.cpp†L119-L132】
+- **Collision helpers** perform dispatch and resolution, invoked during the world's collision sweep before physics updates run.【F:src/collision/collision.h†L8-L27】【F:src/core/world.cpp†L142-L160】
+- **Rendering** is isolated to the `Renderer` namespace so the world only needs to forward entities and the SDL renderer handle.【F:src/rendering/renderer.h†L12-L27】【F:src/core/world.cpp†L70-L83】
+- **UI management** keeps transient UI actions and components outside the main world logic while still being triggered each frame.【F:src/ui/ui_manager.h†L24-L38】【F:src/core/world.cpp†L180-L206】

--- a/docs/collision.md
+++ b/docs/collision.md
@@ -1,0 +1,13 @@
+# Collision Detection
+
+## Collision Types
+
+The engine distinguishes between no collider, circle colliders, and AABB colliders via the `Collision_Type` enum shared across shapes and entities.【F:src/collision/collision_types.h†L8-L14】【F:src/core/entity.h†L22-L26】 Shapes advertise their collider support so the dispatcher can choose the right algorithm.【F:src/shapes/shape.h†L21-L33】
+
+## Dispatch Pipeline
+
+`initialize_collision_system` prepares any global collision data, while `is_colliding` performs shape-aware overlap checks and returns a collision normal when contact occurs.【F:src/collision/collision.h†L8-L23】【F:src/core/world.cpp†L142-L155】 A broad-phase AABB helper is available for fast rejection before expensive shape tests run.【F:src/collision/collision.h†L18-L23】
+
+## Response Handling
+
+When a collision normal is returned, the world defers to `handle_collision`, which applies the appropriate resolution routine for the two entities involved.【F:src/collision/collision.h†L24-L27】【F:src/core/world.cpp†L142-L155】 After resolution, the world records the entity pair so it can detect when collisions end and re-enable gravity or other stateful effects.【F:src/core/world.cpp†L148-L178】

--- a/docs/core.md
+++ b/docs/core.md
@@ -1,0 +1,13 @@
+# Core Systems
+
+## Entities
+
+Entities bundle a renderable shape, a physics component, draw color, and collision metadata, all identified by a unique `entity_id`.【F:src/core/entity.h†L22-L58】 Factory helpers exist for quickly creating circle or rectangle entities with preconfigured physics traits.【F:src/core/entity.h†L54-L58】 Position and velocity accessors simply forward to the underlying physics component so motion logic stays encapsulated.【F:src/core/entity.h†L37-L51】
+
+## World Orchestration
+
+`World` owns the collection of active entities and is responsible for the simulation loop. It counts entities, supports batched insertion, and exposes `update`, `render`, and UI handling entry points.【F:src/core/world.h†L27-L60】【F:src/core/world.cpp†L42-L206】 Initialization sequences set up the renderer, collision system, SDL window, and UI manager before gameplay begins.【F:src/core/world.cpp†L22-L112】【F:src/core/world.cpp†L186-L206】 During each frame, the world tracks elapsed time, clears stale collision pairs, runs broad collision checks, and invokes each physics component's update with shape area information.【F:src/core/world.cpp†L54-L132】【F:src/core/world.cpp†L142-L160】
+
+## Math Utilities
+
+`Vector2D` is a lightweight struct supplying component access and a suite of helper functions for arithmetic, magnitudes, distances, and dot products.【F:src/core/vector.h†L8-L27】 These utilities are used throughout the physics and collision systems for deterministic calculations.

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -1,0 +1,17 @@
+# Physics Components
+
+## Shared Interface
+
+All physics behaviors derive from `Physics_Component`, which standardizes position, velocity, static state management, and an `update(delta_time, area)` hook invoked each frame.【F:src/physics/physics_component.h†L22-L63】【F:src/core/world.cpp†L119-L132】 The base class also tracks conversions between pixel and meter units so components can interpret geometry consistently.【F:src/physics/physics_component.h†L37-L63】
+
+## Rigid Bodies
+
+`Rigid_Body` models mass-based dynamics with configurable acceleration, friction, restitution, and gravity toggles.【F:src/physics/rigid_body.h†L15-L55】 It exposes helpers for applying forces or impulses, making it suitable for most interactive objects that need realistic momentum.
+
+## Particles
+
+`Particle` trades complexity for lightweight updates, adding lifetime tracking for short-lived effects while still supporting gravity and configurable mass.【F:src/physics/particle.h†L11-L38】 Use this component for visual bursts or debris where deterministic motion is less critical.
+
+## Kinematic Controllers
+
+`Kinematic` components serve scripted or player-controlled actors. They maintain acceleration and optional gravity influence while leaving final velocities under caller control.【F:src/physics/kinematic.h†L11-L37】 Because they implement the same interface, kinematic entities plug into the world loop without additional branching.

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -1,0 +1,9 @@
+# Rendering
+
+## Renderer Namespace
+
+The `Renderer` namespace provides a minimal interface for drawing entities: `render_entity` accepts the entity, SDL renderer, optional texture, and a fill flag, while `initialize_render_system` configures any global SDL state before use.【F:src/rendering/renderer.h†L12-L27】 Entities are expected to expose their shapes and colors so the renderer can translate physics state into pixels.
+
+## Frame Composition
+
+During `World::render`, the engine clears the screen to a dark grey, draws each entity via `Renderer::render_entity`, and then lets UI components paint on top before swapping buffers.【F:src/core/world.cpp†L70-L83】【F:src/core/world.cpp†L196-L206】 This keeps gameplay visuals and overlays synchronized without duplicating SDL code across modules.

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1,0 +1,13 @@
+# Shapes
+
+## Base Interface
+
+`Shape` defines the common interface for all renderable geometries, including type identification, collider reporting, area computation, and a normalized area helper used by physics updates.【F:src/shapes/shape.h†L21-L33】 Shapes also track whether they participate in collisions so purely visual elements can opt out.【F:src/shapes/shape.h†L28-L33】
+
+## Circle
+
+`Circle` stores a radius and reports itself as a circular collider, supplying both absolute and pixels-per-meter normalized areas for use in physics calculations.【F:src/shapes/circle.h†L15-L30】 Radius getters and setters allow dynamic resizing at runtime.【F:src/shapes/circle.h†L24-L27】
+
+## Rectangle
+
+`Rectangle` keeps width and height dimensions, supports optional collider enablement, and implements AABB area calculations alongside normalized area output.【F:src/shapes/rectangle.h†L15-L34】 Use the provided accessors to tweak dimensions without rebuilding the entity.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,13 @@
+# Testing
+
+## Component Suites
+
+Low-level math and physics behavior is validated under `test/components`. Vector helpers cover arithmetic, magnitudes, distances, and normalization to ensure deterministic physics inputs.【F:test/components/vector2d_test.cpp†L1-L68】 The shared physics interface and rigid body implementation are checked for correct default state, getters/setters, and impulse handling so motion stays predictable.【F:test/components/physics_component_test.cpp†L1-L31】【F:test/components/rigid_body_test.cpp†L1-L32】 Collision helpers verify both broad-phase AABB rejection and overlap normals for circle entities.【F:test/components/collision_test.cpp†L1-L28】
+
+## Integration Coverage
+
+`test/ui/world_test.cpp` exercises world lifecycle behaviors, confirming entity counting, batch insertion, and SDL-backed initialization/teardown routines.【F:test/ui/world_test.cpp†L1-L38】 These integration checks ensure the main loop wiring remains stable when refactoring core systems.
+
+## Extending Tests
+
+When adding new modules, place unit tests alongside similar coverage under `test/components` or `test/ui`, update `CMakeLists.txt` if new binaries are needed, and rely on `ctest` discovery to pick up the additional targets automatically.【F:CMakeLists.txt†L102-L120】

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,13 @@
+# User Interface
+
+## Manager Lifecycle
+
+`UiManager` owns UI components, queues pending UI actions, and requires parent window/renderer pointers supplied during construction.【F:src/ui/ui_manager.h†L24-L38】 Initialization hooks set up default widgets, while `handleEvents` funnels SDL events through each component for processing.【F:src/ui/ui_manager.h†L33-L36】【F:src/core/world.cpp†L186-L206】
+
+## UI Actions
+
+UI interactions are expressed as `UIAction` structs describing the action type, target position, optional component, and RTTI tag, enabling deferred handling without tight coupling to specific widgets.【F:src/ui/ui_action.h†L17-L36】 Actions enter the manager's queue and are processed in batches so gameplay code can enqueue UI work from anywhere in the update loop.【F:src/ui/ui_manager.h†L29-L36】
+
+## Components
+
+The base `UiComponent` interface (see `components/ui_component.h`) exposes an event handler that returns actions. The included `PopupComponent` example renders an SDL window overlay and converts mouse events into open/close requests while tracking its own renderer and color palette.【F:src/ui/components/ui_popup.h†L12-L24】 During rendering, the world iterates active UI components so overlays draw after gameplay entities.【F:src/core/world.cpp†L196-L206】


### PR DESCRIPTION
## Summary
- create a docs/ folder with module-specific guides for architecture, core systems, physics, collision, shapes, rendering, UI, and testing
- link the README to the new documentation index for easier discovery

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d99ee713c0832797eaa0d7b72a248a